### PR TITLE
Fix: Collection Modification Issue (1.5)

### DIFF
--- a/1.5/Source/LifeSupportComp.cs
+++ b/1.5/Source/LifeSupportComp.cs
@@ -18,21 +18,25 @@ namespace LifeSupport {
             
             //Check for state change in surrounding pawns in beds.
             Map map = parent.Map;
-
-            foreach (var pawn in parent.CellsAdjacent8WayAndInside()
-                                       .SelectMany(cell => cell.GetThingList(map).Where(thing => thing is Building_Bed).SelectMany(thing => (thing as Building_Bed).CurOccupants))
-                                       .Where(pawn => !pawn.health.Dead)
-                                       .Distinct()) {
+            var pawns = parent.CellsAdjacent8WayAndInside()
+                                .SelectMany(cell => cell.GetThingList(map).OfType<Building_Bed>().SelectMany(bed => bed.CurOccupants))
+                                .Where(pawn => !pawn.health.Dead)
+                                .Distinct()
+                                .ToList();
+            
+            foreach (var pawn in pawns) {
                 LifeSupportUtility.SetHediffs(pawn);
             }
         }
         public override void PostDestroy(DestroyMode mode, Map previousMap)
         {
-            foreach (var pawn in parent.CellsAdjacent8WayAndInside()
-                                       .SelectMany(cell => cell.GetThingList(previousMap).Where(thing => thing is Building_Bed).SelectMany(thing => (thing as Building_Bed).CurOccupants))
-                                       .Where(pawn => !pawn.health.Dead)
-                                       .Distinct())
-            {
+            var pawns = parent.CellsAdjacent8WayAndInside()
+                                .SelectMany(cell => cell.GetThingList(previousMap).OfType<Building_Bed>().SelectMany(bed => bed.CurOccupants))
+                                .Where(pawn => !pawn.health.Dead)
+                                .Distinct()
+                                .ToList();
+            
+            foreach (var pawn in pawns) {
                 LifeSupportUtility.SetHediffs(pawn, false);
             }
         }


### PR DESCRIPTION
Update LifeSupportComp to create a copy of the pawns collection before iterating. This change addresses the issue where losing power while using another building that utilises the LifeSupport.CompProperties_LifeSupport comp class would cause a "Collection was modified" error.